### PR TITLE
Fix bug with bold heading

### DIFF
--- a/markdown-to-org.el
+++ b/markdown-to-org.el
@@ -149,8 +149,8 @@ The conversion is done in a specific order to handle nested structures correctly
 
     ;; Convert bold (**) and italic (_)
     (goto-char (point-min))
-    (while (re-search-forward "\\*\\*\\([^*\n]+\\)\\*\\*" nil t)
-      (replace-match "*\\1*"))
+    (while (re-search-forward "\\([^*]\\)\\*\\*\\([^*\n]+\\)\\*\\*" nil t)
+      (replace-match "\\1*\\2*"))
     (goto-char (point-min))
     (while (re-search-forward "_\\([^_\n]+\\)_" nil t)
       (replace-match "/\\1/"))


### PR DESCRIPTION
Heading like
```text
## **heading**

was transforming to

* *heading**

now it transforms properly to

** *heading*
```